### PR TITLE
Update class-gestsup-api.php

### DIFF
--- a/inc/classes/class-gestsup-api.php
+++ b/inc/classes/class-gestsup-api.php
@@ -1,12 +1,12 @@
 <?php
+namespace WPGC\GestSupAPI;
+
 use Carbon_Fields\Container;
 use Carbon_Fields\Field;
 use Carbon_Fields\Helper\Helper;
 use function add_action;
 use function carbon_get_post_meta;
 use function carbon_get_theme_option;
-
-namespace WPGC\GestSupAPI;
 
 use const ARRAY_A;
 use function array_push;


### PR DESCRIPTION
La déclaration de l'espace de noms (namespace) doit être la première déclaration dans le fichier. 

Résoud le problème d'activation du plugin sous Wordpress 6.3.1